### PR TITLE
Jackie transaction fee

### DIFF
--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -12,7 +12,6 @@ contract CauseContract {
 
     // blockchange wallet address
     address payable blockchange;
-    // uint256 feePercent = 1;
 
     // human-readable contract id
     string id;

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -52,13 +52,15 @@ contract CauseContract {
         return ContractInfo(id, admin, incoming, outgoing, contractAddress);
     }
 
+
     function donate() public payable {
-        require(msg.value > 0, "You must send some Ether");
+    require(msg.value > 0, "You must send some Ether");
 
-        incoming.push(Transaction(msg.sender, msg.value * (100 - feePercent) / 100, block.timestamp, block.number, tx.gasprice, 2));
+    uint256 transactionFee = (msg.value * tx.gasprice * 5) / 10000; // Transaction fee of 5bps
+    incoming.push(Transaction(msg.sender, msg.value - transactionFee, block.timestamp, block.number, tx.gasprice, transactionFee));
 
-        blockchange.transfer(msg.value * feePercent / 100);
-    }
+    blockchange.transfer(transactionFee);
+}
 
     function withdraw(uint256 _amount) public payable onlyAdmin {
         require(address(this).balance > _amount, "There is no Ether to withdraw");

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -54,12 +54,12 @@ contract CauseContract {
 
 
     function donate() public payable {
-    require(msg.value > 0, "You must send some Ether");
+        require(msg.value > 0, "You must send some Ether");
 
-    uint256 transactionFee = (msg.value * tx.gasprice * 5) / 10000; // Transaction fee of 5bps
-    incoming.push(Transaction(msg.sender, msg.value - transactionFee, block.timestamp, block.number, tx.gasprice, transactionFee));
+        uint256 transactionFee = (msg.value * tx.gasprice * 5) / 10000; // Transaction fee of 5bps
+        incoming.push(Transaction(msg.sender, msg.value - transactionFee, block.timestamp, block.number, tx.gasprice, transactionFee));
 
-    blockchange.transfer(transactionFee);
+        blockchange.transfer(transactionFee);
 }
 
     function withdraw(uint256 _amount) public payable onlyAdmin {

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -41,7 +41,7 @@ contract CauseContract {
         address contractAddress;
     }
 
-    uint256 constant BASIS_POINTS = 5; // move the basic points to its own variable
+    uint256 constant BASIS_POINTS = 50; // move the basic points to its own variable
     uint256 constant DECIMALS = 1e18; // change the amount to amount * 1e18 in function (withdraw), unit: Wei-> ETH
 
     constructor(string memory _id) {

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -42,7 +42,6 @@ contract CauseContract {
     }
 
     uint256 constant BASIS_POINTS = 50; // move the basic points to its own variable
-    uint256 constant DECIMALS = 1e18; // change the amount to amount * 1e18 in function (withdraw), unit: Wei-> ETH
 
     constructor(string memory _id) {
         admin = payable(msg.sender);
@@ -54,19 +53,21 @@ contract CauseContract {
         return ContractInfo(id, admin, incoming, outgoing, contractAddress);
     }
 
-
-    function donate() public payable {
+    uint256 public transactionFee;
+    
+    function donate() public payable returns (uint256) {
         require(msg.value > 0, "You must send some Ether");
 
-        uint256 transactionFee = (msg.value * tx.gasprice * BASIS_POINTS) / 10000; // Transaction fee of 5bps (by default)
+        transactionFee = (msg.value * tx.gasprice * BASIS_POINTS) / 10000; // Transaction fee of 50bps (by default)
         incoming.push(Transaction(msg.sender, msg.value - transactionFee, block.timestamp, block.number, tx.gasprice, transactionFee));
 
         blockchange.transfer(transactionFee);
-}
-
+        return transactionFee; // Fee in Wei
+    }
+    
     function withdraw(uint256 _amount) public payable onlyAdmin {
         require(address(this).balance > _amount, "There is no Ether to withdraw");
-        uint256 amount = _amount * DECIMALS;
+        uint256 amount = _amount * 1 ether;
         outgoing.push(Transaction(msg.sender, amount, block.timestamp, block.number, tx.gasprice, 2));
 
         // use the transfer method to transfer the amount to the admin's address

--- a/CauseFactory.sol
+++ b/CauseFactory.sol
@@ -8,7 +8,12 @@ contract CauseFactory {
     // store all deployed causes
     mapping(string => CauseContract) public deployedCauses;
 
+    function checkIfIdUnique(string memory _id) public view returns (bool) {
+        return address(deployedCauses[_id]) == address(0);
+    }
+
     function createCauseContract(string memory _id) public {
+        require(checkIfIdUnique(_id), "ID already exists");
         CauseContract newCause = new CauseContract(_id);
         deployedCauses[_id] = newCause;
     }
@@ -17,3 +22,4 @@ contract CauseFactory {
         return deployedCauses[_id].retrieveInfo();
     }
 }
+


### PR DESCRIPTION
Change the transaction fee to 5 basic points.

In addition, I've found that when we call the withdraw function to withdraw money, the unit is Wei, while when we call the donate function to donate money, the unit is ETH. 
```solidity
function withdraw(uint256 _amount) public payable onlyAdmin {
        require(address(this).balance > _amount, "There is no Ether to withdraw");
        outgoing.push(Transaction(msg.sender, _amount, block.timestamp, block.number, tx.gasprice, 2));

        // use the transfer method to transfer the amount to the admin's address
        (bool success, ) = admin.call{value: _amount}("");
        require(success, "Withdrawal failed");
    }
``` 
This makes that after we donate some ETH, we have to input 18 zeros in order to withdraw 1 ETH.
If we set the withdraw "_amount" to "_amount * 1e18", then the withdraw will be at least 1 ETH, if our contract only has less than 1 ETH balance, then the withdraw will fail.

Should we handle this problem? And how should we deal with the decimals?

