### PR TITLE
Jc gas fee opt and delete cause

### DIFF
--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -18,6 +18,9 @@ contract CauseContract {
     // donation total tracker
     uint256 causeTotal;
 
+    // cause withdrawal total tracker
+    uint256 causeWithdrawalTotal;
+
     // Transaction fee of 50bps (by default)
     uint256 constant BASIS_POINTS = 50;
     // Add transactionFeeBasisPoints variable for gas optimization
@@ -55,6 +58,7 @@ contract CauseContract {
         Transaction[] outgoing;
         address contractAddress;
         uint256 causeTotal;
+        uint256 causeWithdrawalTotal;
         uint256 causeState;
         string email;
         string description;
@@ -96,6 +100,7 @@ contract CauseContract {
             outgoing, 
             address(this),
             causeTotal, 
+            causeWithdrawalTotal,
             causeState, 
             email, 
             description, websiteURL, thumbnailURL);
@@ -129,7 +134,7 @@ contract CauseContract {
     function withdraw(uint256 _amount) public payable onlyAdmin {
         require(address(this).balance > _amount, "Insufficient funds for withdrawal");
        
-        causeTotal -= _amount;
+        causeWithdrawalTotal += _amount;
        
         // (bool success, ) = admin.call{value: _amount}("");
         // require(success, "Withdrawal failed");
@@ -147,6 +152,12 @@ contract CauseContract {
 
     function updateAdmin(address _newAdmin) public onlyAdmin {
         admin = payable(_newAdmin);
+
+    }
+
+    function getAdmin() public view returns (address){
+        return admin;
+
     }
 
     function toggleCauseState() public onlyAdmin {
@@ -187,10 +198,6 @@ contract CauseContract {
         donate();
     }
 
-    function getAdmin() public view returns (address) {
-        return admin;
-    }
-
     function setCauseStateInactive() public onlyAdmin {
         causeState = 2;
     }
@@ -201,8 +208,4 @@ contract CauseContract {
         _;
     }
 
-//     modifier onlyOwner() {
-//     require(owner == msg.sender, "You are not the owner of this contract");
-//     _;
-// }
 }

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -136,12 +136,8 @@ contract CauseContract {
        
         causeWithdrawalTotal += _amount;
        
-        // (bool success, ) = admin.call{value: _amount}("");
-        // require(success, "Withdrawal failed");
-
-        // Replace call method with transfer for gas optimization
-        // But be aware of possible security risks
-        admin.transfer(_amount);
+        (bool success, ) = admin.call{value: _amount}("");
+        require(success, "Withdrawal failed");
 
         outgoing.push(Transaction(msg.sender, _amount, block.timestamp, block.number));
     }

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -195,7 +195,7 @@ contract CauseContract {
         causeState = 2;
     }
 
-    // modifier to ensure only admin is able to call function
+    // modifier to ensure only admin or contract factory is able to call function
     modifier onlyAdmin() {
         require(admin == msg.sender || blockChange == msg.sender, "You are not the admin of this contract");
         _;

--- a/CauseContract.sol
+++ b/CauseContract.sol
@@ -6,8 +6,11 @@ contract CauseContract {
     // admin address
     address payable admin;
 
-    // contract address
-    address payable contractAddress;
+    // Contract owner address
+    // address public owner;
+
+    // Contract address
+    address contractAddress = address(this);
 
     // blockChange wallet address
     address payable blockChange;
@@ -15,8 +18,11 @@ contract CauseContract {
     // donation total tracker
     uint256 causeTotal;
 
+    // Transaction fee of 50bps (by default)
     uint256 constant BASIS_POINTS = 50;
-    
+    // Add transactionFeeBasisPoints variable for gas optimization
+    uint256 transactionFeeBasisPoints;
+
     // cause inputs
     string id;
     string name;
@@ -24,7 +30,7 @@ contract CauseContract {
     string websiteURL;
     string thumbnailURL;
     string email;
-    
+   
     // incoming donations
     Transaction[] incoming;
 
@@ -32,8 +38,9 @@ contract CauseContract {
     Transaction[] outgoing;
 
     // donor proportion tracking
-    mapping(address => uint256) public donorTotals;
-    
+    mapping(address => uint256) public donorTotals;    
+
+    // mapping used for unique address identification in redistribute funds function
     mapping(address => bool) public addressDonated;
 
     // causeState flag -> 1 = active, 2 = inactive
@@ -61,16 +68,16 @@ contract CauseContract {
         uint256 amount;
         uint256 timestamp;
         uint256 blockNumber;
-        uint256 gasUsed;
-        uint256 transactionFee;
     }
 
     constructor(string memory _id, string memory _name, address payable _admin, string memory _description, string memory _websiteURL, string memory _thumbnailURL, string memory _email) {
         admin = _admin;
-        contractAddress = payable(address(this));
-
+        // owner = msg.sender; // creator of the contract
         blockChange = payable(msg.sender);
-        
+
+        // Calculate transactionFeeBasisPoints only once during contract creation
+        transactionFeeBasisPoints = BASIS_POINTS / 1000;
+       
         // initialise cause inputs
         id = _id;
         name = _name;
@@ -87,7 +94,7 @@ contract CauseContract {
             admin, 
             incoming, 
             outgoing, 
-            contractAddress, 
+            address(this),
             causeTotal, 
             causeState, 
             email, 
@@ -98,42 +105,40 @@ contract CauseContract {
         require(msg.value > 0, "You must send some Ether");
         require(causeState == 1, "This cause has ended, your funds have been returned");
 
-        uint256 gasStart = gasleft();
+        // Use transactionFeeBasisPoints to calculate transactionFee
+        uint256 transactionFee = msg.value * transactionFeeBasisPoints;
 
-        uint256 transactionFee = (msg.value*BASIS_POINTS) / 1000; // Transaction fee of 5bps (by default)
-        
-        // (bool success, ) = blockChange.call{value: transactionFee}("");
-        // require(success, "Transfer failed.");
 
-        uint256 gasUsed = gasStart - gasleft();
-        uint256 gasPrice = tx.gasprice;
-        uint256 gasFee = gasUsed * gasPrice;
+        // `msg.value - transactionFee` was used twice -> store it in a variable to save gas
+        // Calculate netDonation and use it later for gas optimization
+        uint256 netDonation = msg.value - transactionFee;
+
+        // Transfer the transactionFee
+        (bool success, ) = blockChange.call{value: transactionFee}("");
+        require(success, "Transfer failed.");
 
         // update donor proportion
         donorTotals[msg.sender] += msg.value;
 
         // update causeTotal
-        causeTotal += (msg.value - transactionFee);
+        causeTotal += netDonation;
 
-        incoming.push(Transaction(msg.sender, msg.value - transactionFee, block.timestamp, block.number, gasFee, transactionFee));          
+        incoming.push(Transaction(msg.sender, netDonation, block.timestamp, block.number));          
     }
 
     function withdraw(uint256 _amount) public payable onlyAdmin {
         require(address(this).balance > _amount, "Insufficient funds for withdrawal");
-        
-        uint256 gasStart = gasleft();
-        
+       
         causeTotal -= _amount;
+       
+        // (bool success, ) = admin.call{value: _amount}("");
+        // require(success, "Withdrawal failed");
 
-        // use the transfer method to transfer the amount to the admin's address
-        (bool success, ) = admin.call{value: _amount}("");
-        require(success, "Withdrawal failed");
+        // Replace call method with transfer for gas optimization
+        // But be aware of possible security risks
+        admin.transfer(_amount);
 
-        uint256 gasUsed = gasStart - gasleft();
-        uint256 gasPrice = tx.gasprice;
-        uint256 gasFee = gasUsed * gasPrice;
-
-        outgoing.push(Transaction(msg.sender, _amount, block.timestamp, block.number, gasFee, 0));
+        outgoing.push(Transaction(msg.sender, _amount, block.timestamp, block.number));
     }
 
     function authenticateAdmin() public view onlyAdmin returns (bool) {
@@ -160,7 +165,7 @@ contract CauseContract {
         uint256 totalDonation = address(this).balance;
 
         // keep track of whether an address has already donated or not
-        for (uint256 i = 0; i < incoming.length; i++) {
+                for (uint256 i = 0; i < incoming.length; i++) {
             address sender = incoming[i].sender;
 
             // check if the address has already donated
@@ -182,9 +187,22 @@ contract CauseContract {
         donate();
     }
 
+    function getAdmin() public view returns (address) {
+        return admin;
+    }
+
+    function setCauseStateInactive() public onlyAdmin {
+        causeState = 2;
+    }
+
     // modifier to ensure only admin is able to call function
     modifier onlyAdmin() {
-        require(admin == msg.sender, "You are not the admin of this contract");
+        require(admin == msg.sender || blockChange == msg.sender, "You are not the admin of this contract");
         _;
     }
+
+//     modifier onlyOwner() {
+//     require(owner == msg.sender, "You are not the owner of this contract");
+//     _;
+// }
 }

--- a/CauseFactory.sol
+++ b/CauseFactory.sol
@@ -11,6 +11,12 @@ contract CauseFactory {
     // store all deployed causes
     mapping(string => CauseContract) public deployedCauses;
 
+    // // CauseFactory Contract
+    // address public owner;
+    // constructor() {
+    //     owner = msg.sender;
+    // }
+
     function checkIfIdUnique(string memory _id) public view returns (bool) {
         return address(deployedCauses[_id]) == address(0);
     }
@@ -21,7 +27,7 @@ contract CauseFactory {
 
         CauseContract newCause = new CauseContract(_id, _name, _admin, _description, _websiteURL, _thumbnailURL, _email);
         deployedCauses[_id] = newCause;
-        
+       
         ids.push(_id);
     }
 
@@ -35,5 +41,35 @@ contract CauseFactory {
 
     function cfRetrieveIds() public view returns (string[] memory) {
         return ids;
+    }
+
+    //     // modifier to ensure only admin is able to call function
+    // modifier onlyAdmin() {
+    //     require(deployedCauses[_id].getAdmin() == msg.sender, "You are not the admin of this contract");
+    //     _;
+    // }
+
+    function deleteCauseContract(string memory _id) public {
+        require(address(deployedCauses[_id]) != address(0), "Cause does not exist");
+        require(deployedCauses[_id].getAdmin() == msg.sender, "You are not the admin of this contract");
+
+        // End the cause and distribute funds to the donors
+        deployedCauses[_id].setCauseStateInactive();
+        // Added condition to check if CauseContract contains funds, if so redistribute (avoids reversion if balance = 0)
+        if(address(deployedCauses[_id]).balance > 0){
+            deployedCauses[_id].distributeFunds();
+        }
+        delete deployedCauses[_id];
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            if (keccak256(abi.encodePacked((ids[i]))) == keccak256(abi.encodePacked((_id)))) {
+                // Maintain order when deleting
+                for (uint256 j = i; j < ids.length - 1; j++){
+                    ids[j] = ids[j + 1];
+                }
+                ids.pop();
+                break;
+            }
+        }
     }
 }

--- a/CauseFactory.sol
+++ b/CauseFactory.sol
@@ -11,11 +11,6 @@ contract CauseFactory {
     // store all deployed causes
     mapping(string => CauseContract) public deployedCauses;
 
-    // // CauseFactory Contract
-    // address public owner;
-    // constructor() {
-    //     owner = msg.sender;
-    // }
 
     function checkIfIdUnique(string memory _id) public view returns (bool) {
         return address(deployedCauses[_id]) == address(0);
@@ -43,11 +38,6 @@ contract CauseFactory {
         return ids;
     }
 
-    //     // modifier to ensure only admin is able to call function
-    // modifier onlyAdmin() {
-    //     require(deployedCauses[_id].getAdmin() == msg.sender, "You are not the admin of this contract");
-    //     _;
-    // }
 
     function deleteCauseContract(string memory _id) public {
         require(address(deployedCauses[_id]) != address(0), "Cause does not exist");


### PR DESCRIPTION
This PR includes all of Jackie's changes made on the gas fee optimsation branch, with my fixes included.

1. Incorporated contract factory address to admin only modifier so that it can execute the cause contract functions required for cause deletion. This delete cause function in the contract factory is locked behind an admin require function so only the admin of the cause contract can execute the delete cause function. 

2. Reversed the changes to the redistribute funds function so that it uses a mapping rather than an array. Now operates well. 

3. Changed donor total back to msg.value so that the redistribute funds proportion ignores transfer fees. 
